### PR TITLE
Shorter namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To declare a service provider, simply implement the `ServiceProvider` interface.
 
 ```php
-use Interop\Container\ServiceProvider\ServiceProvider;
+use Interop\Container\ServiceProvider;
 
 class MyServiceProvider implements ServiceProvider
 {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Interop\\Container\\ServiceProvider\\": "src/"
+            "Interop\\Container\\ServiceProvider": "src/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Interop\\Container\\ServiceProvider": "src/"
+            "Interop\\Container\\": "src/"
         }
     },
     "require": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Container\ServiceProvider;
+namespace Interop\Container;
 
 interface ServiceProvider
 {


### PR DESCRIPTION
`Interop\Container\ServiceProvider\ServiceProvider` is very long, the sub-namespace might not be necessary.

I *think* the Composer configuration for autoloading should work, but if someone can confirm?

What do you think?