### PR TITLE
Splitting getServices in 2 methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A factory/extension can provide PHP objects (services) as well as any value. Sim
 
 ### Returning `null`
 
-A factory/extension can return `null`. In this case, the container consuming the service provider MUST NOT register any service.
+A factory/extension can return `null`. In this case, the container consuming the service provider MUST register a service that is `null`.
 
 ```php
     public function getFactories()
@@ -129,7 +129,8 @@ A factory/extension can return `null`. In this case, the container consuming the
 ```
 
 ```php
-$container->has('my_service') // Returns false
+$container->has('my_service') // Returns true
+$container->get('my_service') // Returns null
 ```
 
 ### Aliases

--- a/src/ServiceProviderInterface.php
+++ b/src/ServiceProviderInterface.php
@@ -14,14 +14,28 @@ interface ServiceProviderInterface
      * - the value is a callable that will return the entry, aka the **factory**
      *
      * Factories have the following signature:
-     *        function(ContainerInterface $container, callable $getPrevious = null)
+     *        function(\Psr\Container\ContainerInterface $container)
+     *
+     * @return callable[]
+     */
+    public function getFactories();
+
+    /**
+     * Returns a list of all container entries extended by this service provider.
+     *
+     * - the key is the entry name
+     * - the value is a callable that will return the modified entry
+     *
+     * Callables have the following signature:
+     *        function(Psr\Container\ContainerInterface $container, $previous)
+     *     or function(Psr\Container\ContainerInterface $container, $previous = null)
      *
      * About factories parameters:
      *
      * - the container (instance of `Psr\Container\ContainerInterface`)
-     * - a callable that returns the previous entry if overriding a previous entry, or `null` if not
+     * - the entry to be extended. If the entry to be extended does not exist and the parameter is nullable, `null` will be passed.
      *
      * @return callable[]
      */
-    public function getServices();
+    public function getExtensions();
 }


### PR DESCRIPTION
Looking at discussions in #21, there is an agreement that the current `$getPrevious` argument is sub-optimal (from a performance point of view).

Also, there have been some discussions to split the current `getServices` in 2 methods.

Arguments advanced for this split:

- @skalpa pointed that working with 2 passes (one about factories and one about extensions) allows the developer not to have to worry about the order of service providers. https://github.com/container-interop/service-provider/issues/21#issuecomment-223923937
- @mindplay-dk pointed in #28 that we have actually 2 different meanings crammed down in the same callable

This PR proposes the following changes:

- Splitting `getServices` into `getFactories` and `getExtensions`. (I think the name `getFactories` is more accurate than the name `getServices` as we are actually returning an array of factories, but I'm ok to revert this back to `getServices` if you prefer)
- Factories returned by `getFactories` now accept only one parameter (the container)
- Callable returned by `getExtensions` accept 2 parameters: the container and the previous service (so I replaced `$getPrevious` with `$previous` which should solve the performance issue with compiled containers from #21 )
- Type-hinting on `$previous` is explicitly allowed and encouraged
- `$previous` CAN be nullable.
- If `$previous` is not nullable, the service MUST exist
- If `$previous` is nullable, `null` is passed if the service does not exist

An important point: I wanted the spec to allow "optional extensions", i.e. an extension to be able to declare that if the extended service does not exist, it is ok. Being able to pass `null` to `$previous` is a first step in that direction, but not enough. The extension callable must return something. So I declared that if an extension (or a factory) returns `null`, this actually means that the service is NOT declared.

```php
    function extendLogger(ContainerInterface $container, ?Logger $logger) : ?Logger
    {
        // If no logger service is defined, let's simply ignore this extension (instead of throwing an error)
        if ($logger === null) {
            // Because we return "null", the service will be considered NOT declared
            return null;
        }

        $logger->addHandler(new SyslogHandler());
        return $logger;
    }
```

This is the part I'm the less comfortable about. It makes a lot of sense BUT for runtime containers, it requires executing the factory to answer a simple `has` method call, which is far from efficient.

Anyway, all this is 100% open to discussion. What do you think about this idea?