### PR TITLE
Allow ^2.0 of psr/container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         }
     },
     "require": {
-        "psr/container": "^1.0"
+        "psr/container": "^1.0 || ^2.0"
     }
 }


### PR DESCRIPTION
Fixes  #56

This seems to be pretty safe since the `ServiceProviderInterface` never **actually** interacts with `ContainerInterface`. Maybe you could even put `@stable` here, but I did not want to go that far