### PR TITLE
Do not require `psr/container` as it is not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,5 @@
         "psr-4": {
             "Interop\\Container\\": "src/"
         }
-    },
-    "require": {
-        "psr/container": "^1.0"
     }
 }


### PR DESCRIPTION
This is counterposed to #57 and in agreement with the argumentation raised in #42